### PR TITLE
Fixes and misc. changes.

### DIFF
--- a/zdcode/__init__.py
+++ b/zdcode/__init__.py
@@ -356,7 +356,7 @@ class ZDActor(ZDBaseActor):
     def get_spawn_label(self):
         for l in self.labels:
             if l.name.upper() == "SPAWN":
-                return self.transform_spawn(l)
+                return l
 
         return None
 
@@ -432,22 +432,6 @@ class ZDActor(ZDBaseActor):
 
         return r
 
-    def transform_spawn(self, label: ZDLabel):
-        if label.states[0].spawn_safe():
-            return label
-
-        # TODO: more comprehensive error handling and warning handling
-        # (sike, ZDCode is not going to get new features!)
-        print(
-            f"Warning: Spawn label of class '{repr(self.name)}' is not spawn safe: "
-            "auto-padding with 'TNT1 A 0'! Silence this warning by manually adding a "
-            "'TNT1 A 0' at the start of the Spawn label."
-        )
-
-        new_label = ZDLabel(self, label.name, label.states, False)
-        new_label.states.insert(0, ZDState.tnt1())
-        return new_label
-
     def label_code(self):
         r = TextNode()
 
@@ -455,9 +439,6 @@ class ZDActor(ZDBaseActor):
             r.add_line(decorate(f[1]))
 
         for l in self.labels:
-            if l.name.upper() == "SPAWN":
-                l = self.transform_spawn(l)
-
             r.add_line(decorate(l))
 
         return r

--- a/zdcode/__init__.py
+++ b/zdcode/__init__.py
@@ -383,14 +383,14 @@ class ZDActor(ZDBaseActor):
                 )
             )
 
+        for rd in self.raw:
+            r.add_line(rd)
+
         for f in self.flags:
             r.add_line("+{}".format(f))
 
         for a in self.antiflags:
             r.add_line("-{}".format(a))
-
-        for rd in self.raw:
-            r.add_line(rd)
 
         if len(r) == 1 and r[0].strip() == "":
             return "    "

--- a/zdcode/zdlexer.py
+++ b/zdcode/zdlexer.py
@@ -583,25 +583,12 @@ def templated_class_derivation():
                             .optional()
                             .map(lambda t: t or "int")
                             .tag("type"),
-                            (
-                                wo.then(s("=")).then(
-                                    expression.tag("val") | array_literal.tag("arr")
-                                )
-                            )
-                            .optional()
-                            .tag("value"),
                         )
                         .map(dict)
                         .tag("user var")
                     )
                     | (
                         (ist("array") << whitespace)
-                        >> seq(
-                            regex(r"user_[a-zA-Z0-9_]+").desc("array name").tag("name"),
-                            (wo >> s("=") >> wo >> array_literal)
-                            .desc("array values")
-                            .tag("value"),
-                        )
                         .map(dict)
                         .desc("override array")
                         .tag("array")
@@ -740,9 +727,6 @@ def class_body():
                 .optional()
                 .map(lambda t: t or "int")
                 .tag("type"),
-                (wo >> s("=") >> (expression.tag("val") | array_literal.tag("arr")))
-                .optional()
-                .tag("value"),
             )
             .map(dict)
             .tag("user var")


### PR DESCRIPTION
(not sure what to title this)
The following changes were made to fix some issues ZDCode had.

First, the unsafe spawn state warning (which was a little broken and would show even with the `TNT1 A 0` state in some cases) and the automatic padding state it generates have been removed. I don't believe ZDCode should take care of this itself, since such a state is not equal to having one with a `NoDelay` flag and this is very important for timing in some places (like spawning from ACS, the first state action is run instantly before the script continues execution. And this is something people using ZDCode would most likely be aware of already.

Second, the ability to initialize user variables was also removed. This wasn't very well implemented (there's no checking if the flags were already set or anything of the sort, so monsters with no idle state and user vars would have their user variables reset upon losing their target), and the rationale for the first change also applies here.

And third, flag combos used to be put after flags/unflags in the compiled classes. This meant, for example, that you couldn't use `Projectile` and then `-NOGRAVITY` afterwards to override that flag being set by the combo.

I doubt I implemented these changes perfectly as I don't 100% understand the source, but if any additional improvements to them are needed or I left over something I'll gladly fix that.